### PR TITLE
Run frontend vitest tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, v0.0.0 ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, v0.0.0 ]
 
 jobs:
   build-and-test:

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,1 +1,15 @@
 import '@testing-library/jest-dom';
+import { afterEach, vi } from 'vitest';
+
+// Stub global fetch during tests to avoid real network calls
+const mockFetch = vi.fn(async () => ({
+	ok: true,
+	json: async () => ({ status: 'ok' }),
+})) as unknown as typeof fetch;
+
+vi.stubGlobal('fetch', mockFetch);
+
+afterEach(() => {
+	// Reset mock between tests
+	(mockFetch as unknown as { mockClear: () => void }).mockClear();
+});

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -3,13 +3,13 @@ import { afterEach, vi } from 'vitest';
 
 // Stub global fetch during tests to avoid real network calls
 const mockFetch = vi.fn(async () => ({
-	ok: true,
-	json: async () => ({ status: 'ok' }),
+  ok: true,
+  json: async () => ({ status: 'ok' }),
 })) as unknown as typeof fetch;
 
 vi.stubGlobal('fetch', mockFetch);
 
 afterEach(() => {
-	// Reset mock between tests
-	(mockFetch as unknown as { mockClear: () => void }).mockClear();
+  // Reset mock between tests
+  (mockFetch as unknown as { mockClear: () => void }).mockClear();
 });


### PR DESCRIPTION
Stub `global.fetch` in Vitest setup to prevent network errors during frontend tests.

---
<a href="https://cursor.com/background-agent?bcId=bc-e9af9a6a-ac38-459c-847a-4b48bc1b70e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e9af9a6a-ac38-459c-847a-4b48bc1b70e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

